### PR TITLE
Fix - split build log entry

### DIFF
--- a/app/lib/database_api.py
+++ b/app/lib/database_api.py
@@ -24,7 +24,8 @@ class BuildLog(Base):
     id = Column(Integer, primary_key=True, index=True)
     commit_hash = Column(String, unique=True, nullable=False)
     build_date = Column(String, nullable=False)
-    build_log = Column(String, nullable=False)
+    test_result = Column(String, nullable=False)
+    lint_result = Column(String, nullable=False)
 
 def init_db():
     """Create database and tables if they don't exist"""
@@ -42,28 +43,28 @@ def get_db():
 def get_entries():
     """Return a list of all existing build logs"""
     db = get_db()
-    return [(entry.id, entry.commit_hash, entry.build_date, entry.build_log) 
+    return [(entry.id, entry.commit_hash, entry.build_date, entry.test_result, entry.lint_result) 
             for entry in db.query(BuildLog).all()]
 
 def get_entry_by_commit(commit_hash: str):
     """Queries database for entry with specified hashsum"""
     db = get_db()
     entry = db.query(BuildLog).filter(BuildLog.commit_hash == commit_hash).first()
-    return [(entry.id, entry.commit_hash, entry.build_date, entry.build_log)] if entry else []
+    return [(entry.id, entry.commit_hash, entry.build_date, entry.test_result, entry.lint_result)] if entry else []
 
 def get_entry_by_id(build_id: int):
     """Queries database for entry with specified id"""
     db = get_db()
     entry = db.query(BuildLog).filter(BuildLog.id == build_id).first()
-    return [(entry.id, entry.commit_hash, entry.build_date, entry.build_log)] if entry else []
+    return [(entry.id, entry.commit_hash, entry.build_date, entry.test_result, entry.lint_result)] if entry else []
 
 def get_entries_by_date(build_date: str):
     """Queries database for all entries made on specified date"""
     db = get_db()
     entries = db.query(BuildLog).filter(BuildLog.build_date == build_date).all()
-    return [(entry.id, entry.commit_hash, entry.build_date, entry.build_log) for entry in entries]
+    return [(entry.id, entry.commit_hash, entry.build_date, entry.test_result, entry.lint_result) for entry in entries]
 
-def create_new_entry(commit_hash: str, build_log: str):
+def create_new_entry(commit_hash: str, test_result: str, lint_result: str):
     """Create a new entry with a given commit hashsum and build log"""
     db = get_db()
     build_date = datetime.today().strftime(time_format)
@@ -75,7 +76,8 @@ def create_new_entry(commit_hash: str, build_log: str):
     new_entry = BuildLog(
         commit_hash=commit_hash,
         build_date=build_date,
-        build_log=build_log
+        test_result=test_result,
+        lint_result=lint_result
     )
     db.add(new_entry)
     db.commit()

--- a/app/routers/builds.py
+++ b/app/routers/builds.py
@@ -165,11 +165,11 @@ async def get_build(build_id: str):
                 <p><strong>Commit Hash:</strong> {commit_hash}</p>
                 <p><strong>Build Date:</strong> {date}</p>
                 <h2>Test-log Log:</h2>
-                <div class="Test-log">
+                <div class="Linter-log">
                     {test_result}
                 </div>
                 <h2>Linter-log:</h2>
-                <div class="Linter-log">
+                <div class="Test-log">
                     {lint_result}
                 </div>
             </div>

--- a/app/routers/builds.py
+++ b/app/routers/builds.py
@@ -164,10 +164,11 @@ async def get_build(build_id: str):
                 <h1>Build #{build_id}</h1>
                 <p><strong>Commit Hash:</strong> {commit_hash}</p>
                 <p><strong>Build Date:</strong> {date}</p>
-                <h2>Build Log:</h2>
+                <h2>Test-log Log:</h2>
                 <div class="Test-log">
                     {test_result}
                 </div>
+                <h2>Linter-log:</h2>
                 <div class="Linter-log">
                     {lint_result}
                 </div>

--- a/app/routers/builds.py
+++ b/app/routers/builds.py
@@ -129,7 +129,8 @@ async def get_build(build_id: str):
     build = build[0]
     commit_hash = build[1]
     date = build[2]
-    build_log = build[3]
+    test_result = build[3]
+    lint_result = build[4]
     
     html_content = f"""
     <html>
@@ -164,8 +165,11 @@ async def get_build(build_id: str):
                 <p><strong>Commit Hash:</strong> {commit_hash}</p>
                 <p><strong>Build Date:</strong> {date}</p>
                 <h2>Build Log:</h2>
-                <div class="build-log">
-                    {build_log}
+                <div class="Test-log">
+                    {test_result}
+                </div>
+                <div class="Linter-log">
+                    {lint_result}
                 </div>
             </div>
         </body>

--- a/database/database_tables.sql
+++ b/database/database_tables.sql
@@ -1,6 +1,0 @@
-CREATE TABLE build_log(
-    commit_hash     TEXT UNIQUE   NOT NULL,
-    build_date      TEXT          NOT NULL,
-    linter_result   TEXT          NOT NULL,
-    test_result     TEXT          NOT NULL
-);


### PR DESCRIPTION
Now the build log should be split into a lint and test field, it seems to work correctly and is displayed reasonably when opening it in a webpage.

Closes #84